### PR TITLE
Added message regeneration ability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [**MinimalChat: A Simple and Customizable LLM Chat App**](https://minimalgpt.app)
 
 ![Build Status](https://img.shields.io/badge/build-passing-brightgreen)
-![Version](https://img.shields.io/badge/version-5.1.0-blue)
+![Version](https://img.shields.io/badge/version-5.1.1-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
 ## Self Host with Docker

--- a/src/components/chat-header.vue
+++ b/src/components/chat-header.vue
@@ -63,16 +63,16 @@ function onShowConversationsClick() {
             <Github :size="20" :stroke-width="2.5" class="header-icon" />
         </a>
         <div class="settings-btn" @click="toggleSidebar">
-            <Settings :stroke-width="0.75" :size="30" />
+            <Settings :stroke-width="1.00" :size="30" />
         </div>
         <div class="trash-btn" @click="deleteCurrentConversation">
-            <Trash2 :stroke-width="0.75" :size="30" />
+            <Trash2 :stroke-width="1.00" :size="30" />
         </div>
         <div class="saved-conversations-dropdown" @click="onShowConversationsClick">
-            <MessagesSquare :stroke-width="0.75" :size="30" />
+            <MessagesSquare :stroke-width="1.00" :size="30" />
         </div>
         <span class="save-icon" @click="clearMessages">
-            <MessageSquareDiff :stroke-width="0.75" :size="30" />
+            <MessageSquareDiff :stroke-width="1.00" :size="30" />
         </span>
     </div>
 </template>

--- a/src/components/conversations-dialog.vue
+++ b/src/components/conversations-dialog.vue
@@ -106,9 +106,9 @@ function toggleSidebar() {
             <h2>
                 Conversations
                 &nbsp;
-                <Eraser @click="purgeConversations" :size="25" :stroke-width="0.75" />&nbsp;
-                <Download @click="exportConversations" :size="25" :stroke-width="0.75" />&nbsp;
-                <Upload @click="importConversations" :size="25" :stroke-width="0.75" />
+                <Eraser @click="purgeConversations" :size="25" :stroke-width="1.00" />&nbsp;
+                <Download @click="exportConversations" :size="25" :stroke-width="1.00" />&nbsp;
+                <Upload @click="importConversations" :size="25" :stroke-width="1.00" />
             </h2>
         </div>
         <div class="sidebar-content-container">

--- a/src/components/settings-dialog.vue
+++ b/src/components/settings-dialog.vue
@@ -69,7 +69,7 @@ function toggleSidebar() {
             <span @click="reloadPage">
                 <RefreshCcw :size="23" :stroke-width="2" />
             </span>
-            Settings | V5.1.0
+            Settings | V5.1.1
         </h2>
     </div>
     <div class="sidebar-content-container">


### PR DESCRIPTION
Users can now regenerate a previous message response in the conversation history. This allows users to adjust model params like temperature or even switch models entirely and then regenerate a previous response.

- Users can now regenerate a message anywhere in the conversation chain.
- Code Syntax highlight adjustment to github-dark-dimmed.
- Simplified message-items html template DOM logic and layout.
- Message bubble color theme updates to align closer to the general site theme.