### PR TITLE
Fix issue with setting empty system prompt in chat interface

### DIFF
--- a/src/views/ChatLayout.vue
+++ b/src/views/ChatLayout.vue
@@ -201,25 +201,31 @@ watch(selectedAutoSaveOption, (newValue) => {
 //#endregion watchers
 
 async function setSystemPrompt(prompt) {
-    // Trim the prompt and check if it is empty
-    if (prompt.trim() === '') {
-        console.error('System prompt cannot be empty');
-        return; // Exit the function if prompt is empty
-    }
-
     // Find the index of the existing system prompt (if any)
     const systemPromptIndex = messages.value.findIndex(message => message.role === 'system');
 
     if (systemPromptIndex === 0) {
-        // Update the existing system prompt (always the first message)
+        // Trim the prompt and check if it is empty
+        if (prompt.trim() === '') {
+            // Remove the system entry entry from the messages ref if the prompt is an empty string
+            messages.value.shift();
+            return;
+        }
+
         messages.value[0].content = prompt;
-    } else {
-        // Add a new system prompt at the beginning of the messages
-        messages.value.unshift({
-            role: 'system',
-            content: prompt
-        });
+        return;
     }
+
+    if (prompt.trim() === '') {
+        return; //Do not add an empty system prompt
+    }
+
+    // Add a new system prompt at the beginning of the messages
+    messages.value.unshift({
+        role: 'system',
+        content: prompt
+    });
+
 }
 
 //#region UI Updates

--- a/src/views/ChatLayout.vue
+++ b/src/views/ChatLayout.vue
@@ -736,6 +736,9 @@ async function sendClaudeMessage(messageText) {
 
 async function regenerateMessageReponse(content) {
     isLoading.value = true;
+
+    setSystemPrompt(systemPrompt.value);
+
     const messageIndex = messages.value.findIndex(message => message.content === content && message.role === 'user');
 
     if (messageIndex !== -1) {

--- a/src/views/ChatLayout.vue
+++ b/src/views/ChatLayout.vue
@@ -201,20 +201,25 @@ watch(selectedAutoSaveOption, (newValue) => {
 //#endregion watchers
 
 async function setSystemPrompt(prompt) {
+    // Trim the prompt and check if it is empty
+    if (prompt.trim() === '') {
+        console.error('System prompt cannot be empty');
+        return; // Exit the function if prompt is empty
+    }
+
     // Find the index of the existing system prompt (if any)
     const systemPromptIndex = messages.value.findIndex(message => message.role === 'system');
 
     if (systemPromptIndex === 0) {
         // Update the existing system prompt (always the first message)
         messages.value[0].content = prompt;
-        return;
+    } else {
+        // Add a new system prompt at the beginning of the messages
+        messages.value.unshift({
+            role: 'system',
+            content: prompt
+        });
     }
-
-    // Add a new system prompt at the beginning of the messages
-    messages.value.unshift({
-        role: 'system',
-        content: prompt
-    });
 }
 
 //#region UI Updates

--- a/src/views/ChatLayout.vue
+++ b/src/views/ChatLayout.vue
@@ -207,7 +207,7 @@ async function setSystemPrompt(prompt) {
     if (systemPromptIndex === 0) {
         // Trim the prompt and check if it is empty
         if (prompt.trim() === '') {
-            // Remove the system entry entry from the messages ref if the prompt is an empty string
+            // Remove the system entry from the messages ref if the prompt is an empty string
             messages.value.shift();
             return;
         }


### PR DESCRIPTION
### Description
This pull request addresses an issue where setting an empty system prompt in the chat interface leads to server errors, specifically in environments like lmstudio, which require non-empty content fields in the messages array. This issue is not unique to lmstudio and could potentially affect other environments that handle system prompts similarly.

### Changes Made

- Added a validation check in the setSystemPrompt function to ensure that empty or whitespace-only prompts are not set. This prevents the application from attempting to update or create a system prompt that would violate backend requirements.
- This update enhances the robustness of the chat system by ensuring all system prompts contain meaningful content, thus preventing runtime errors and improving overall data integrity.

### Impact
No downsides have been identified with this change. It prevents the front end from sending invalid data to the server, aligning with typical backend validations and ensuring smoother operation across different environments.

### Additional Notes
This fix was implemented following best practices for input validation, ensuring the application behaves as expected even when user input might otherwise lead to errors.