### PR TITLE
Updated parseOpenAiFormatResponseChunk to strip OpenRouter ending text

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -77,13 +77,14 @@ export function parseOpenAiFormatResponseChunk(chunk) {
     for (const line of completeLines) {
         let cleanedLine = line.trim();
 
-        // Removing multiple occurrences of "data:" and any "[DONE]" tags
+        // Removing multiple occurrences of "data:", any "[DONE]" tags, and ": OPENROUTER PROCESSING"
         // Regex explanation:
         // - \[DONE\]: Matches the literal "[DONE]"
         // - \s*: Matches any whitespace characters (space, tab, newline, etc.)
         // - data:\s*: Matches "data:" followed by any whitespace
+        // - : OPENROUTER PROCESSING: Matches the literal ": OPENROUTER PROCESSING"
         // Global flag 'g' to replace all occurrences throughout the string
-        cleanedLine = cleanedLine.replace(/\[DONE\]\s*|data:\s*/gi, '');
+        cleanedLine = cleanedLine.replace(/\[DONE\]\s*|data:\s*|: OPENROUTER PROCESSING/gi, '');
 
         if (cleanedLine !== '') {
             try {
@@ -96,8 +97,6 @@ export function parseOpenAiFormatResponseChunk(chunk) {
     }
     return results;
 }
-
-
 
 export function showToast(message) {
     Toastify({
@@ -113,5 +112,4 @@ export function showToast(message) {
         },
         onClick: function () { } // Callback after click
     }).showToast();
-
 }


### PR DESCRIPTION
OpenRouter at times passing back `: OPENROUTER PROCESSING` in the data that causes normal OpenAI format stream processing to blow up. I've expanded the regex slightly in `parseOpenAiFormatResponseChunk` so that it will strip that text out if it occurs.

This is always at the end of the message so when it errors it doesn't really impact the user in any way. It just throws a console error, which bugs me.

This seems to fix any console errors that appear.

Closes Issue #89 