### PR TITLE
Add a max_tokens limit to the title generation

### DIFF
--- a/src/libs/open-ai-api-standard-access.js
+++ b/src/libs/open-ai-api-standard-access.js
@@ -158,6 +158,7 @@ export async function getConversationTitleFromLocalModel(messages, model, localM
                 stream: true,
                 messages: tempMessages,
                 temperature: 0.25,
+                max_tokens: 32,
                 top_P: parseFloat(localStorage.getItem("top_P") || 1.0),
                 repetition_penalty: parseFloat(localStorage.getItem("repetitionPenalty") || 1.0)
             }),


### PR DESCRIPTION
### Purpose
Prevent local models with weaker instruction following from generating infinite titles.

### Changes
Added a "max_tokens" parameter with a low (32 token) value to the inference request.

### Notes
There's still iffyness in the conversation title generation for local, but this should prevent the worst case scenario where a user ends up generating a title indefinitely.