### PR TITLE
Add import/export functionality to settings-dialog

### DIFF
--- a/src/libs/settings-utils.js
+++ b/src/libs/settings-utils.js
@@ -1,0 +1,60 @@
+export function handleExportSettings(props, exportSettingsToFile) {
+    const settingsData = {
+        isSidebarOpen: props.isSidebarOpen,
+        selectedModel: props.selectedModel,
+        localModelName: props.localModelName,
+        localModelEndpoint: props.localModelEndpoint,
+        localModelKey: props.localModelKey,
+        huggingFaceEndpoint: props.huggingFaceEndpoint,
+        localSliderValue: props.localSliderValue,
+        gptKey: props.gptKey,
+        sliderValue: props.sliderValue,
+        claudeKey: props.claudeKey,
+        claudeSliderValue: props.claudeSliderValue,
+        selectedDallEImageCount: props.selectedDallEImageCount,
+        selectedDallEImageResolution: props.selectedDallEImageResolution,
+        selectedAutoSaveOption: props.selectedAutoSaveOption,
+        browserModelSelection: props.browserModelSelection,
+        maxTokens: props.maxTokens,
+        top_P: props.top_P,
+        repetitionPenalty: props.repetitionPenalty,
+        systemPrompt: props.systemPrompt
+    };
+
+    exportSettingsToFile(settingsData);
+}
+
+export function exportSettingsToFile(settingsData) {
+    const filename = "minimal-chat-settings.json";
+    const text = JSON.stringify(settingsData, null, 2);  // Pretty print JSON
+
+    let element = document.createElement('a');
+    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+    element.setAttribute('download', filename);
+    element.style.display = 'none';
+    document.body.appendChild(element);
+
+    element.click();
+
+    document.body.removeChild(element);
+}
+
+export function handleImportSettings(event, importSettings) {
+    const file = event.target.files[0];
+    if (file) {
+        const reader = new FileReader();
+        reader.onload = function (e) {
+            const settingsData = JSON.parse(e.target.result);
+            importSettings(settingsData);
+        };
+        reader.readAsText(file);
+    }
+}
+
+export function importSettings(settingsData, update) {
+    for (const key in settingsData) {
+        if (settingsData.hasOwnProperty(key)) {
+            update(key, settingsData[key]);
+        }
+    }
+}


### PR DESCRIPTION
**This pull request integrates dedicated import and export functionalities into settings-dialog.vue, enhancing the configuration management capabilities of the application.**

### Changes:
- **New Config Section**: Introduced a new configuration section specifically for import/export functionalities within `settings-dialog.vue`.
- **Utility Functions**: Added a new file `settings-utils.js` which contains all utility functions related to settings importing and exporting. This includes functions for handling the import and export of settings and conversations. 
- **Code Clean-Up**: In the future more of the settings related functionalities could be moved here for a cleaner code base.

### Benefits:
- **Enhanced Usability**: Users can now easily manage import and export actions directly from the settings dialog, improving the overall user experience.

I had planned to move the conversation importing and exporting into the settings as well, but had some problems with that., will tackle it at a later date again.
