### PR TITLE
Add AI Avatar Image Uploading/Selecting and General UI/UX Improvements

### DIFF
--- a/src/components/configuration-sections/GeneralConfigSection.vue
+++ b/src/components/configuration-sections/GeneralConfigSection.vue
@@ -5,15 +5,24 @@
                 @update:value="handleUpdate('systemPrompt', $event)" :isSecret="false" :isMultiline="true"
                 :placeholderText="'Enter the system prompt if applicable.'" />
         </div>
-        <div v-if="systemPrompts.length" class="saved-system-prompts">
-            <h4>Saved System Prompts:</h4>
-            <ul>
-                <li v-for="(prompt, index) in systemPrompts" :key="index"
-                    :class="{ selected: index === selectedSystemPromptIndex }" @click="handleSelectSystemPrompt(index)">
-                    <Trash2 :size="18" :stroke-width="1.5" @click.stop="handleDeleteSystemPrompt(index)" />
-                    &nbsp;&nbsp;{{ prompt }}
-                </li>
-            </ul>
+        <div class="saved-system-prompts-section">
+            <h4 @click="isSavedPromptsOpen = !isSavedPromptsOpen">
+                Saved System Prompts
+                <ChevronDown v-if="isSavedPromptsOpen" class="indicator" size="20" />
+                <ChevronRight v-else class="indicator" size="20" />
+            </h4>
+            <transition name="slide-fade">
+                <div v-show="isSavedPromptsOpen && systemPrompts.length" class="saved-system-prompts">
+                    <ul>
+                        <li v-for="(prompt, index) in systemPrompts" :key="index"
+                            :class="{ selected: index === selectedSystemPromptIndex }"
+                            @click="handleSelectSystemPrompt(index)">
+                            <Trash2 :size="18" :stroke-width="1.5" @click.stop="handleDeleteSystemPrompt(index)" />
+                            &nbsp;&nbsp;{{ prompt }}
+                        </li>
+                    </ul>
+                </div>
+            </transition>
         </div>
         <br>
         <br>

--- a/src/components/configuration-sections/GeneralConfigSection.vue
+++ b/src/components/configuration-sections/GeneralConfigSection.vue
@@ -27,23 +27,214 @@
         <br>
         <br>
         <div class="control-checkbox">
-            <SliderCheckbox inputId="higher-contrast-messages" labelText="Higher Contrast Messages:"
+            <SliderCheckbox inputId="higher-contrast-messages" labelText="Higher Contrast Messages"
                 v-model="higherContrastMessages" @update:modelValue="handleUpdate('higherContrastMessages', $event)" />
         </div>
         <br>
+        <br>
+        <div class="config-section" :class="{ show: isAvatarSectionOpen }">
+            <h3 @click="isAvatarSectionOpen = !isAvatarSectionOpen">
+                AI Message Avatar
+                <ChevronDown v-if="isAvatarSectionOpen" class="indicator" size="20" />
+                <ChevronRight v-else class="indicator" size="20" />
+            </h3>
+            <transition name="slide-fade">
+                <div v-show="isAvatarSectionOpen" class="control-grid">
+                    <div class="control-checkbox">
+                        <SliderCheckbox inputId="enable-ai-avatar" labelText="Enable AI Avatar"
+                            v-model="isAvatarEnabled" />
+                    </div>
+                    <div class="avatar-url-container">
+                        <InputField labelText="Avatar Image URL:" inputId="avatar-url" :value="avatarUrl"
+                            @update:value="handleUpdate('avatarUrl', $event)" :isSecret="false" :isMultiline="false"
+                            :placeholderText="'Enter the URL for the AI avatar image'" />
+                        <br>
+                        <h4>Select an image from stored files or upload a new one:</h4>
+                        <Listbox v-model="selectedFile" :options="storedFiles" optionLabel="fileName"
+                            @change="updateAvatarUrl" class="w-full md:w-14rem select-listbox" :filter="true">
+                            <template #header>
+                                <Button label="Upload Avatar" icon="pi pi-upload" class="custom-upload-button"
+                                    @click="triggerFileInput" />
+                            </template>
+                            <template #option="slotProps">
+                                <div class="flex align-items-center">
+                                    <Avatar :image="slotProps.option.fileData" :alt="slotProps.option.fileName"
+                                        shape="circle" size="large" />
+                                    <div class="ml-2">{{ slotProps.option.fileName }}</div>
+                                </div>
+                            </template>
+                        </Listbox>
+                        <input type="file" ref="fileInput" style="display: none" @change="uploadFile"
+                            accept="image/*" />
+                    </div>
+
+                </div>
+            </transition>
+        </div>
         <br>
     </div>
 </template>
 
 <script setup>
 import InputField from '@/components/controls/InputField.vue';
-import { Trash2 } from 'lucide-vue-next';
-import { systemPrompt, selectedAutoSaveOption, higherContrastMessages } from '@/libs/state-management/state';
+import { ChevronDown, ChevronRight, Trash2 } from 'lucide-vue-next';
+import { isAvatarEnabled, avatarUrl, systemPrompt, selectedAutoSaveOption, higherContrastMessages } from '@/libs/state-management/state';
 import { handleUpdate, handleDeleteSystemPrompt, handleSelectSystemPrompt, selectedSystemPromptIndex, systemPrompts } from '@/libs/utils/settings-utils';
 import SliderCheckbox from '../controls/SliderCheckbox.vue';
+import { ref, onMounted, onBeforeMount } from 'vue';
+import { storeFileData } from '@/libs/file-processing/image-analysis';
+import { showToast } from '@/libs/utils/general-utils';
+
+const storedFiles = ref([]);
+const selectedFile = ref(null);
+const fileInput = ref(null);
+
+const isAvatarSectionOpen = ref(false);
+
+const fetchStoredFiles = async () => {
+    try {
+        const request = indexedDB.open('UserFilesDB', 4);
+
+        const db = await new Promise((resolve, reject) => {
+            request.onsuccess = (event) => resolve(event.target.result);
+            request.onerror = reject;
+        });
+
+        const transaction = db.transaction(['userFiles'], 'readonly');
+        const store = transaction.objectStore('userFiles');
+        const getAllRequest = store.getAll();
+
+        const result = await new Promise((resolve, reject) => {
+            getAllRequest.onsuccess = () => resolve(getAllRequest.result);
+            getAllRequest.onerror = reject;
+        });
+
+        return result.filter(file => file.fileType && file.fileType.startsWith('image/'));
+    } catch (error) {
+        console.error(`Error Fetching Stored Files: ${error}`);
+        return [];
+    }
+};
+
+const uploadFile = async (event) => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = async (e) => {
+        const contents = e.target.result;
+        await storeFileData(file.name, contents, file.size, file.type);
+        showToast('Image uploaded and stored successfully');
+        storedFiles.value = await fetchStoredFiles();
+    };
+    reader.readAsDataURL(file);
+};
+
+const triggerFileInput = () => {
+    fileInput.value.click();
+};
+
+const updateAvatarUrl = () => {
+    if (selectedFile.value) {
+        handleUpdate('avatarUrl', selectedFile.value.fileData);
+    }
+};
+
+onBeforeMount(async () => {
+    storedFiles.value = await fetchStoredFiles();
+});
 </script>
 
-<style scoped lang="scss">
+<style lang="scss">
+.slide-fade-enter-active,
+.slide-fade-leave-active {
+    transition: all 0.15s linear;
+    max-height: 90vh;
+}
+
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(-20px);
+}
+
+.p-header {
+    padding: 6px;
+}
+
+.custom-upload-button {
+    border: 1px solid #157474;
+    color: #157474;
+    background-color: transparent;
+    transition: all 0.3s ease;
+    min-width: 100%;
+
+    &:hover {
+        background-color: rgba(21, 116, 116, 0.1);
+        border-color: #1a8f8f;
+    }
+
+    .p-button {
+        display: flex;
+        color: #157474;
+        min-width: 99vw;
+    }
+}
+
+.config-section {
+    margin-bottom: 15px;
+
+    h3 {
+        margin-bottom: 15px;
+        background-color: transparent;
+        border-bottom: 4px solid #1a4c47e6;
+        text-align: left;
+        position: relative;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        cursor: pointer;
+        padding: 8px;
+    }
+
+    .control-grid {
+        display: grid;
+        grid-template-columns: repeat(1, 1fr);
+        gap: 20px;
+    }
+}
+
+.flex {
+    display: flex;
+}
+
+.align-items-center {
+    align-items: center;
+}
+
+.ml-2 {
+    margin-left: 0.5rem;
+}
+
+.slide-fade-enter-active,
+.slide-fade-leave-active {
+    transition: all 0.1s linear;
+    max-height: 90vh;
+}
+
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(-20px);
+}
+
+
+.avatar-url-container {
+    margin-top: 10px;
+}
+
 .p-dropdown {
     background-color: transparent;
     border-bottom: 2px solid #157474;
@@ -64,6 +255,14 @@ import SliderCheckbox from '../controls/SliderCheckbox.vue';
     }
 }
 
+.p-listbox {
+
+    .p-icon {
+        color: #157474;
+        right: 14px;
+        top: 11px;
+    }
+}
 
 .system-prompt-container,
 .saved-system-prompts {

--- a/src/components/configuration-sections/GptConfigSection.vue
+++ b/src/components/configuration-sections/GptConfigSection.vue
@@ -45,56 +45,62 @@ const dalleImageResolutionOptions = [
             maxLabel="Creative" @update:modelValue="updateGptSliderValue" />
         <br>
         <br>
-        <div class="config-section" :class="{ show: isWhisperConfigSectionOpen }">
+        <div class="config-section">
             <h3 @click="isWhisperConfigSectionOpen = !isWhisperConfigSectionOpen">
                 Interact Mode
                 <ChevronDown v-if="isWhisperConfigSectionOpen" class="indicator" size="20" />
                 <ChevronRight v-else class="indicator" size="20" />
             </h3>
-            <div v-show="isWhisperConfigSectionOpen" class="control-grid">
-                <SliderCheckbox inputId="push-to-talk" labelText="Push to Talk Mode" v-model="pushToTalkMode"
-                    @update:modelValue="handleUpdate('use-push-to-talk', $event)" />
-                <SliderCheckbox inputId="use-whisper" labelText="Whisper Transcriptions" v-model="useWhisper"
-                    @update:modelValue="handleUpdate('use-whisper', $event)" />
-                <div class="control select-dropdown">
-                    <label for="tts-model">TTS Model:</label>&nbsp;
-                    <Dropdown checkmark id="tts-model" :options="ttsModelOptions" v-model="ttsModel" optionLabel="label"
-                        optionValue="value" @change="handleUpdate('tts-model', $event.value)"></Dropdown>
+            <transition name="slide-fade">
+                <div v-show="isWhisperConfigSectionOpen" class="control-grid">
+                    <SliderCheckbox inputId="push-to-talk" labelText="Push to Talk Mode" v-model="pushToTalkMode"
+                        @update:modelValue="handleUpdate('use-push-to-talk', $event)" />
+                    <SliderCheckbox inputId="use-whisper" labelText="Whisper Transcriptions" v-model="useWhisper"
+                        @update:modelValue="handleUpdate('use-whisper', $event)" />
+                    <div class="control select-dropdown">
+                        <label for="tts-model">TTS Model:</label>&nbsp;
+                        <Dropdown checkmark id="tts-model" :options="ttsModelOptions" v-model="ttsModel"
+                            optionLabel="label" optionValue="value" @change="handleUpdate('tts-model', $event.value)">
+                        </Dropdown>
+                    </div>
+                    <div class="control select-dropdown">
+                        <label for="tts-voice">TTS Voice:</label>&nbsp;
+                        <Dropdown checkmark id="tts-voice" :options="ttsVoiceOptions" v-model="ttsVoice"
+                            optionLabel="label" optionValue="value" @change="handleUpdate('tts-voice', $event.value)">
+                        </Dropdown>
+                    </div>
+                    <InputField :isSecret="false" labelText="Audio Speed:"
+                        :placeholderText="'Example: Default is 1.0 and 1.05 would be 5% faster playback.'"
+                        inputId="audio-speed" :value="audioSpeed" @update:value="handleUpdate('audio-speed', $event)" />
+                    <ToolTip :targetId="'audio-speed'">Default is 1.0 and 1.05 would be 5% faster playback.</ToolTip>
+                    <Slider label="Temperature" v-model="whisperTemperature" :min="0" :max="1" :step="0.01"
+                        minLabel="Serious" maxLabel="Creative" @update:modelValue="updateWhisperSlider" />
                 </div>
-                <div class="control select-dropdown">
-                    <label for="tts-voice">TTS Voice:</label>&nbsp;
-                    <Dropdown checkmark id="tts-voice" :options="ttsVoiceOptions" v-model="ttsVoice" optionLabel="label"
-                        optionValue="value" @change="handleUpdate('tts-voice', $event.value)"></Dropdown>
-                </div>
-                <InputField :isSecret="false" labelText="Audio Speed:"
-                    :placeholderText="'Example: Default is 1.0 and 1.05 would be 5% faster playback.'"
-                    inputId="audio-speed" :value="audioSpeed" @update:value="handleUpdate('audio-speed', $event)" />
-                <ToolTip :targetId="'audio-speed'">Default is 1.0 and 1.05 would be 5% faster playback.</ToolTip>
-                <Slider label="Temperature" v-model="whisperTemperature" :min="0" :max="1" :step="0.01"
-                    minLabel="Serious" maxLabel="Creative" @update:modelValue="updateWhisperSlider" />
-            </div>
+            </transition>
         </div>
         <br>
-        <div class="config-section" :class="{ show: isDALLEConfigOpen }">
+        <div class="config-section">
             <h3 @click="isDALLEConfigOpen = !isDALLEConfigOpen">
                 DALL-E
                 <ChevronDown v-if="isDALLEConfigOpen" class="indicator" size="20" />
                 <ChevronRight v-else class="indicator" size="20" />
             </h3>
-            <div v-show="isDALLEConfigOpen" class="control-grid">
-                <div class="control select-dropdown">
-                    <label for="dalle-image-count">DALL-E Image Count:</label>&nbsp;
-                    <Dropdown checkmark id="dalle-image-count" :options="dalleImageCountOptions"
-                        v-model="selectedDallEImageCount" optionLabel="label" optionValue="value"
-                        @change="handleUpdate('selectedDallEImageCount', $event.value)"></Dropdown>
+            <transition name="slide-fade">
+                <div v-show="isDALLEConfigOpen" class="control-grid">
+                    <div class="control select-dropdown">
+                        <label for="dalle-image-count">DALL-E Image Count:</label>&nbsp;
+                        <Dropdown checkmark id="dalle-image-count" :options="dalleImageCountOptions"
+                            v-model="selectedDallEImageCount" optionLabel="label" optionValue="value"
+                            @change="handleUpdate('selectedDallEImageCount', $event.value)"></Dropdown>
+                    </div>
+                    <div class="control select-dropdown">
+                        <label for="dalle-image-resolution">Image Resolution:</label>&nbsp;
+                        <Dropdown checkmark id="dalle-image-resolution" :options="dalleImageResolutionOptions"
+                            v-model="selectedDallEImageResolution" optionLabel="label" optionValue="value"
+                            @change="handleUpdate('selectedDallEImageResolution', $event.value)"></Dropdown>
+                    </div>
                 </div>
-                <div class="control select-dropdown">
-                    <label for="dalle-image-resolution">Image Resolution:</label>&nbsp;
-                    <Dropdown checkmark id="dalle-image-resolution" :options="dalleImageResolutionOptions"
-                        v-model="selectedDallEImageResolution" optionLabel="label" optionValue="value"
-                        @change="handleUpdate('selectedDallEImageResolution', $event.value)"></Dropdown>
-                </div>
-            </div>
+            </transition>
         </div>
     </div>
 </template>
@@ -161,6 +167,19 @@ const dalleImageResolutionOptions = [
     }
 }
 
+.slide-fade-enter-active,
+.slide-fade-leave-active {
+    transition: all 0.15s ease;
+    max-height: 90vh;
+}
+
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(-20px);
+}
+
 .config-section {
     margin-bottom: 15px;
 
@@ -177,25 +196,10 @@ const dalleImageResolutionOptions = [
         padding: 8px;
     }
 
-    .config-info {
-        font-size: 12px;
-    }
-
     .control-grid {
         display: grid;
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(1, 1fr);
         gap: 20px;
-        transition: max-height 0.3s ease-in-out;
-        overflow: hidden;
-        max-height: 0;
-
-        @media (max-width: 600px) {
-            grid-template-columns: repeat(1, 1fr);
-        }
-    }
-
-    &.show .control-grid {
-        max-height: fit-content;
     }
 }
 

--- a/src/components/configuration-sections/ImportExportConfigSection.vue
+++ b/src/components/configuration-sections/ImportExportConfigSection.vue
@@ -1,73 +1,73 @@
 <template>
-    <div class="config-section" :class="{ show: isImportExportConfigOpen }">
+    <div class="config-section">
         <h3 @click="isImportExportConfigOpen = !isImportExportConfigOpen">
             Import/Export Configuration
             <ChevronDown v-if="isImportExportConfigOpen" class="indicator" size="20" />
             <ChevronRight v-else class="indicator" size="20" />
         </h3>
-        <div v-show="isImportExportConfigOpen" class="control-grid">
-            <h4>
-                Manage Settings
-                <p class="config-info">
-                    Export your current settings to a JSON file for backup or to easily set up the application on
-                    another
-                    device. You can also import
-                    settings from a JSON file.
-                </p>
-            </h4>
+        <transition name="slide-fade">
+            <div v-show="isImportExportConfigOpen" class="control-grid">
+                <h4>
+                    Manage Settings
+                    <p class="config-info">
+                        Export your current settings to a JSON file for backup or to easily set up the application on
+                        another device. You can also import settings from a JSON file.
+                    </p>
+                </h4>
 
-            <div class="settings-list">
-                <div class="settings-item-button" @click="
-                    handleExportSettings(
-                        {
-                            shouldShowScrollButton,
-                            userText,
-                            isLoading,
-                            hasFilterText,
-                            selectedModel,
-                            isSidebarOpen,
-                            showConversationOptions,
-                            messages,
-                            streamedMessageText,
-                            modelDisplayName,
-                            localModelKey,
-                            localModelName,
-                            localModelEndpoint,
-                            localSliderValue,
-                            gptKey,
-                            sliderValue,
-                            claudeKey,
-                            claudeSliderValue,
-                            selectedDallEImageCount,
-                            selectedDallEImageResolution,
-                            selectedAutoSaveOption,
-                            browserModelSelection,
-                            maxTokens,
-                            top_P,
-                            repetitionPenalty,
-                            systemPrompt,
-                            conversations,
-                            storedConversations,
-                            lastLoadedConversationId,
-                            selectedConversation,
-                            abortController,
-                            imageInput,
-                        },
-                        exportSettingsToFile
-                    )
-                    ">
-                    <span class="action-text">Export Settings</span>
-                    <Download :stroke-width="1.5" />
+                <div class="settings-list">
+                    <div class="settings-item-button" @click="
+                        handleExportSettings(
+                            {
+                                shouldShowScrollButton,
+                                userText,
+                                isLoading,
+                                hasFilterText,
+                                selectedModel,
+                                isSidebarOpen,
+                                showConversationOptions,
+                                messages,
+                                streamedMessageText,
+                                modelDisplayName,
+                                localModelKey,
+                                localModelName,
+                                localModelEndpoint,
+                                localSliderValue,
+                                gptKey,
+                                sliderValue,
+                                claudeKey,
+                                claudeSliderValue,
+                                selectedDallEImageCount,
+                                selectedDallEImageResolution,
+                                selectedAutoSaveOption,
+                                browserModelSelection,
+                                maxTokens,
+                                top_P,
+                                repetitionPenalty,
+                                systemPrompt,
+                                conversations,
+                                storedConversations,
+                                lastLoadedConversationId,
+                                selectedConversation,
+                                abortController,
+                                imageInput,
+                            },
+                            exportSettingsToFile
+                        )
+                        ">
+                        <span class="action-text">Export Settings</span>
+                        <Download :stroke-width="1.5" />
+                    </div>
+                    <label class="settings-item-button">
+                        <span class="action-text">Import Settings</span>
+                        <Upload :stroke-width="1.5" />
+                        <input type="file" accept=".json"
+                            @change="(event) => handleImportSettings(event, (data) => importSettings(data, update))"
+                            style="display: none" />
+                    </label>
                 </div>
-                <label class="settings-item-button">
-                    <span class="action-text">Import Settings</span>
-                    <Upload :stroke-width="1.5" />
-                    <input type="file" accept=".json"
-                        @change="(event) => handleImportSettings(event, (data) => importSettings(data, update))"
-                        style="display: none" />
-                </label>
             </div>
-        </div>
+        </transition>
     </div>
 </template>
 
@@ -82,6 +82,19 @@ const isImportExportConfigOpen = ref(false);
 </script>
 
 <style scoped lang="scss">
+.slide-fade-enter-active,
+.slide-fade-leave-active {
+    transition: all 0.15s ease;
+    max-height: 90vh;
+}
+
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(-20px);
+}
+
 .config-section {
     margin-bottom: 15px;
 
@@ -98,25 +111,10 @@ const isImportExportConfigOpen = ref(false);
         padding: 8px;
     }
 
-    .config-info {
-        font-size: 12px;
-    }
-
     .control-grid {
         display: grid;
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(1, 1fr);
         gap: 20px;
-        transition: max-height 0.3s ease-in-out;
-        overflow: hidden;
-        max-height: 0;
-
-        @media (max-width: 600px) {
-            grid-template-columns: repeat(1, 1fr);
-        }
-    }
-
-    &.show .control-grid {
-        max-height: fit-content;
     }
 }
 

--- a/src/components/configuration-sections/LocalConfigSection.vue
+++ b/src/components/configuration-sections/LocalConfigSection.vue
@@ -3,6 +3,8 @@
         <InputField :isSecret="false" labelText="API Endpoint:" :placeholderText="'Enter the base API Endpoint URL'"
             inputId="local-model-endpoint" :value="localModelEndpoint"
             @update:value="handleUpdate('localModelEndpoint', $event)" />
+        <ToolTip targetId="local-model-endpoint">Updating this value will automatically save a new custom config entry
+        </ToolTip>
         <InputField :isSecret="true" labelText="API Key:" :placeholderText="'Enter the API key if applicable'"
             inputId="local-model-key" :value="localModelKey" @update:value="handleUpdate('localModelKey', $event)" />
     </div>
@@ -13,16 +15,18 @@
             <ChevronDown v-if="isParametersOpen" class="indicator" size="20" />
             <ChevronRight v-else class="indicator" size="20" />
         </h3>
-        <div v-show="isParametersOpen" class="control-grid">
-            <Slider label="Temperature" v-model="localSliderValue" :min="0" :max="1" :step="0.01" minLabel="Serious"
-                maxLabel="Creative" @update:modelValue="updateLocalSliderValue" />
-            <Slider label="Top_P" v-model="top_P" :min="0" :max="1" :step="0.01" minLabel="Lower" maxLabel="Higher"
-                @update:modelValue="updateTopPSliderValue" />
-            <Slider label="Repetition Penalty" v-model="repetitionPenalty" :min="0" :max="2" :step="0.01"
-                minLabel="Lower" maxLabel="Higher" @update:modelValue="updateRepetitionSliderValue" />
-            <Slider label="Max Tokens" v-model="maxTokens" :min="-1" :max="4096" :step="1" minLabel="Less"
-                maxLabel="More" @update:modelValue="updateMaxTokensSliderValue" />
-        </div>
+        <transition name="slide-fade">
+            <div v-show="isParametersOpen" class="control-grid">
+                <Slider label="Temperature" v-model="localSliderValue" :min="0" :max="1" :step="0.01" minLabel="Serious"
+                    maxLabel="Creative" @update:modelValue="updateLocalSliderValue" />
+                <Slider label="Top_P" v-model="top_P" :min="0" :max="1" :step="0.01" minLabel="Lower" maxLabel="Higher"
+                    @update:modelValue="updateTopPSliderValue" />
+                <Slider label="Repetition Penalty" v-model="repetitionPenalty" :min="0" :max="2" :step="0.01"
+                    minLabel="Lower" maxLabel="Higher" @update:modelValue="updateRepetitionSliderValue" />
+                <Slider label="Max Tokens" v-model="maxTokens" :min="-1" :max="4096" :step="1" minLabel="Less"
+                    maxLabel="More" @update:modelValue="updateMaxTokensSliderValue" />
+            </div>
+        </transition>
     </div>
     <br>
     <div class="config-section" :class="{ show: isModelSelectorOpen }">
@@ -31,12 +35,14 @@
             <ChevronDown v-if="isModelSelectorOpen" class="indicator" size="20" />
             <ChevronRight v-else class="indicator" size="20" />
         </h3>
-        <div v-show="isModelSelectorOpen" class="control-grid">
-            <div class="control select-dropdown select-listbox">
-                <Listbox filter id="custom-model-selector" v-model="localModelName" :options="availableModels"
-                    optionLabel="name" optionValue="id" @change="handleUpdate('localModelName', $event.value)" />
+        <transition name="slide-fade">
+            <div v-show="isModelSelectorOpen" class="control-grid">
+                <div class="control select-dropdown select-listbox">
+                    <Listbox filter id="custom-model-selector" v-model="localModelName" :options="availableModels"
+                        optionLabel="name" optionValue="id" @change="handleUpdate('localModelName', $event.value)" />
+                </div>
             </div>
-        </div>
+        </transition>
     </div>
 </template>
 
@@ -48,6 +54,7 @@ import Listbox from 'primevue/listbox';
 import Slider from '../controls/Slider.vue';
 import { localModelEndpoint, localModelKey, localModelName, maxTokens, localSliderValue, top_P, repetitionPenalty, availableModels, selectedModel } from '@/libs/state-management/state';
 import { handleUpdate, updateLocalSliderValue, updateTopPSliderValue, updateRepetitionSliderValue, customConfigs, selectedCustomConfigIndex, updateMaxTokensSliderValue } from '@/libs/utils/settings-utils';
+import ToolTip from '../controls/ToolTip.vue';
 
 
 const isModelSelectorOpen = ref(false);
@@ -55,6 +62,19 @@ const isParametersOpen = ref(false);
 </script>
 
 <style scoped lang="scss">
+.slide-fade-enter-active,
+.slide-fade-leave-active {
+    transition: all 0.15s ease;
+    max-height: 90vh;
+}
+
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(-20px);
+}
+
 .config-section {
     margin-bottom: 15px;
 
@@ -75,13 +95,6 @@ const isParametersOpen = ref(false);
         display: grid;
         grid-template-columns: repeat(1, 1fr);
         gap: 20px;
-        transition: max-height 0.3s ease-in-out;
-        overflow: hidden;
-        max-height: 0;
-    }
-
-    &.show .control-grid {
-        max-height: fit-content;
     }
 }
 

--- a/src/components/controls/MessageItem.vue
+++ b/src/components/controls/MessageItem.vue
@@ -19,6 +19,8 @@ import {
     selectedConversation,
     modelDisplayName,
     higherContrastMessages,
+    isAvatarEnabled,
+    avatarUrl,
 } from '@/libs/state-management/state';
 import {
     setSystemPrompt,
@@ -36,6 +38,7 @@ import csharp from 'highlight.js/lib/languages/csharp';
 import python from 'highlight.js/lib/languages/python';
 import 'highlight.js/styles/github-dark.css';
 import MarkdownIt from 'markdown-it';
+import Avatar from 'primevue/avatar';
 
 hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('c', c);
@@ -260,8 +263,11 @@ const menuItems = computed(() => {
         }
     }" class="p-ripple box" v-if="active" :class="messageClass(item.role)">
         <div class="message-header">
-            <ContextMenu v-if="item" ref="menu" :model="menuItems" :id="'message-menu-' + item.id" />
             <i v-if="item.role === 'user'" class="pi pi-ellipsis-h delete-icon" @click="menu.toggle($event)"></i>
+            <Avatar v-if="item.role !== 'user' && isAvatarEnabled === true" :image="avatarUrl" shape="circle"
+                size="large" />
+            <ContextMenu v-if="item" ref="menu" :model="menuItems" :id="'message-menu-' + item.id" />
+
             <div class="label" @click="copyText(item.content)" :id="'message-label-' + item.id">
                 {{ item.role === 'user' ? '' : modelDisplayName }}
             </div>
@@ -349,6 +355,13 @@ const menuItems = computed(() => {
             justify-content: end;
             right: 1%;
             position: relative;
+
+            display: flex;
+            align-items: center;
+
+            .p-avatar {
+                margin-right: 10px;
+            }
         }
 
         .label:hover {
@@ -384,6 +397,12 @@ const menuItems = computed(() => {
         .message-header {
             justify-content: start;
             border-bottom: 2px solid #0b6363e5;
+            display: flex;
+            align-items: center;
+
+            .p-avatar {
+                margin-right: 10px;
+            }
         }
 
         .label:hover {
@@ -397,6 +416,7 @@ const menuItems = computed(() => {
         gap: 8px;
         color: #dadbde;
         padding: 3px 6px;
+
 
         .label {
             color: #dadbde;

--- a/src/components/controls/MessageItem.vue
+++ b/src/components/controls/MessageItem.vue
@@ -274,6 +274,17 @@ const menuItems = computed(() => {
 </template>
 <!-- MessageItem.vue -->
 <style lang="scss">
+.scale-enter-from,
+.scale-leave-to {
+    transition: all 0.15s ease-out;
+    transform: scale(0);
+}
+
+.scale-enter-to,
+.scale-leave-from {
+    transform: scale(1);
+}
+
 .p-menuitem {
     padding: 4px;
 

--- a/src/components/controls/MessagesList.vue
+++ b/src/components/controls/MessagesList.vue
@@ -1,27 +1,22 @@
-<!-- Original component (e.g., MessageList.vue) -->
 <template>
   <div ref="messageList" class="message-list" @swiped-left="swipedLeft" @swiped-right="swipedRight"
     data-swipe-threshold="15" data-swipe-unit="vw" data-swipe-timeout="500">
-    <DynamicScroller :min-item-size="1200" :buffer="1200" ref="scroller" class="scroller" :emitUpdates="true"
-      :items="filteredMessages" key-field="id" v-slot="{ item, active }">
-      <DynamicScrollerItem :item="item" :active="active" :data-index="item.id">
-        <MessageItem :item="item" :active="active" />
-      </DynamicScrollerItem>
-    </DynamicScroller>
+    <VirtualScroller :items="filteredMessages" :itemSize="1200" class="scroller" :scrollHeight="'87vh'" :delay="0"
+      :lazy="true" :showLoader="false">
+      <template #item="{ item, index }">
+        <MessageItem :item="item" :active="true" :key="item.id" />
+      </template>
+    </VirtualScroller>
   </div>
 </template>
 
 <script setup>
 import { ref, nextTick, computed, watch, onMounted } from 'vue';
-import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller';
-import 'vue-virtual-scroller/dist/vue-virtual-scroller.css';
-import {
-  messages,
-  isSmallScreen,
-} from '@/libs/state-management/state';
+import { messages } from '@/libs/state-management/state';
 import { swipedLeft, swipedRight } from '@/libs/utils/general-utils';
 import 'swiped-events';
 import MessageItem from '@/components/controls/MessageItem.vue';
+import VirtualScroller from 'primevue/virtualscroller';
 
 const messageList = ref(null);
 const scroller = ref(null);
@@ -46,6 +41,20 @@ watch(
 </script>
 
 <style lang="scss" scoped>
+.p-virtualscroller {
+  height: 87vh;
+  width: 100%;
+}
+
+.p-virtualscroller-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.p-virtualscroller-item {
+  flex: 0 0 auto;
+}
+
 .scroller,
 .message-list {
   height: 87vh;

--- a/src/components/controls/MessagesList.vue
+++ b/src/components/controls/MessagesList.vue
@@ -1,22 +1,27 @@
+<!-- Original component (e.g., MessageList.vue) -->
 <template>
   <div ref="messageList" class="message-list" @swiped-left="swipedLeft" @swiped-right="swipedRight"
     data-swipe-threshold="15" data-swipe-unit="vw" data-swipe-timeout="500">
-    <VirtualScroller :items="filteredMessages" :itemSize="1200" class="scroller" :scrollHeight="'87vh'" :delay="0"
-      :lazy="true" :showLoader="false">
-      <template #item="{ item, index }">
-        <MessageItem :item="item" :active="true" :key="item.id" />
-      </template>
-    </VirtualScroller>
+    <DynamicScroller :min-item-size="1200" :buffer="1200" ref="scroller" class="scroller" :emitUpdates="true"
+      :items="filteredMessages" key-field="id" v-slot="{ item, active }">
+      <DynamicScrollerItem :item="item" :active="active" :data-index="item.id">
+        <MessageItem :item="item" :active="active" />
+      </DynamicScrollerItem>
+    </DynamicScroller>
   </div>
 </template>
 
 <script setup>
 import { ref, nextTick, computed, watch, onMounted } from 'vue';
-import { messages } from '@/libs/state-management/state';
+import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller';
+import 'vue-virtual-scroller/dist/vue-virtual-scroller.css';
+import {
+  messages,
+  isSmallScreen,
+} from '@/libs/state-management/state';
 import { swipedLeft, swipedRight } from '@/libs/utils/general-utils';
 import 'swiped-events';
 import MessageItem from '@/components/controls/MessageItem.vue';
-import VirtualScroller from 'primevue/virtualscroller';
 
 const messageList = ref(null);
 const scroller = ref(null);
@@ -41,20 +46,6 @@ watch(
 </script>
 
 <style lang="scss" scoped>
-.p-virtualscroller {
-  height: 87vh;
-  width: 100%;
-}
-
-.p-virtualscroller-content {
-  display: flex;
-  flex-direction: column;
-}
-
-.p-virtualscroller-item {
-  flex: 0 0 auto;
-}
-
 .scroller,
 .message-list {
   height: 87vh;

--- a/src/components/controls/SliderCheckbox.vue
+++ b/src/components/controls/SliderCheckbox.vue
@@ -1,5 +1,3 @@
-<!-- src/components/controls/SliderCheckbox.vue -->
-
 <script setup>
 import { ref, defineProps, defineEmits } from 'vue';
 

--- a/src/components/controls/ToolTip.vue
+++ b/src/components/controls/ToolTip.vue
@@ -5,6 +5,7 @@ import 'tippy.js/animations/shift-away-subtle.css';
 
 const props = defineProps({
   targetId: String,
+  customClass: String,
 });
 
 const tooltipElement = ref(null);
@@ -23,10 +24,14 @@ const createTooltip = () => {
         animation: 'shift-away-subtle',
         interactive: false,
         hideOnClick: true,
+        theme: 'custom',
+        maxWidth: 250,
+        delay: [200, 0], // Add a small delay before showing the tooltip
       });
     }
   }
 };
+
 
 onMounted(() => {
   createTooltip();
@@ -40,19 +45,31 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div ref="tooltipElement" class="tooltip-container">
+  <div ref="tooltipElement" :class="['tooltip-container', customClass]">
     <slot></slot>
   </div>
 </template>
 
 <style lang="scss">
 .tooltip-container {
-  padding: 8px;
-  background-color: #333;
+  padding: 8px 12px;
+  background-color: #094444de;
   color: white;
-  border-radius: 4px;
+  border-radius: 6px;
   font-size: 14px;
   z-index: 1000001;
   pointer-events: none;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  max-width: 250px;
+  line-height: 1.4;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.tippy-box[data-animation='shift-away-subtle'][data-state='hidden'] {
+  opacity: 0;
+}
+
+.tippy-arrow {
+  color: rgba(26, 89, 81, 0.95);
 }
 </style>

--- a/src/components/dialogs/SettingsDialog.vue
+++ b/src/components/dialogs/SettingsDialog.vue
@@ -36,7 +36,7 @@ import {
 
 } from '@/libs/utils/settings-utils';
 import "swiped-events";
-import { Settings, Trash2 } from 'lucide-vue-next';
+import { ChevronDown, ChevronRight, Settings, Trash2 } from 'lucide-vue-next';
 
 // Visibility states for collapsible config sections
 const isClaudeConfigOpen = ref(false);
@@ -110,11 +110,17 @@ function showGeneralConfigSection() {
   isSidebarVisible.value = false;
 }
 
-function selectCustomModel(configName) {
-  selectedModel.value = 'open-ai-format';
-  selectedCustomConfig.value = configName;
+function selectCustomModel(index) {
+  handleSelectCustomConfig(index);
+  // selectedCustomConfig.value = configName;
+
+  showingGeneralConfig.value = false;
+  isClaudeConfigOpen.value = false;
+  isGPTConfigOpen.value = false;
+  isCustomConfigOpen.value = false;
 
   isSidebarVisible.value = false;
+
 }
 
 function selectModel(model) {
@@ -182,7 +188,7 @@ onMounted(() => {
   <div class="settings-dialog" data-swipe-threshold="15" data-swipe-unit="vw" data-swipe-timeout="500"
     @swiped-right="swipedRight">
     <DialogHeader title="Configuration" :icon="Settings" :iconSize="32"
-      tooltipText="Current Version: 6.2.5 Neural Nexus 🧠" headerId="settings-header"
+      tooltipText="Current Version: 6.2.5 Fluid Fusion (Pre-Release)" headerId="settings-header"
       @close="() => isSidebarOpen = false" />
     <div class="settings-container">
       <Sidebar v-model:visible="isSidebarVisible" :baseZIndex="3" @hide="isSidebarVisible = false">
@@ -212,7 +218,7 @@ onMounted(() => {
             <ul v-show="isCustomConfigOpen">
               <li v-for="(config, index) in customConfigs" :key="config.endpoint"
                 :class="{ selected: selectedModel === 'open-ai-format' && localModelEndpoint === config.endpoint }"
-                @click="handleSelectCustomConfig(index)">
+                @click="selectCustomModel(config.endpoint, index)">
                 <Trash2 :size="18" :stroke-width="1.5" @click.stop="handleDeleteCustomConfig(index)" />&nbsp;&nbsp;
                 {{ config.endpoint }}
               </li>
@@ -231,33 +237,38 @@ onMounted(() => {
           <li :class="{ selected: showingGeneralConfig }" @click="showGeneralConfigSection">
             General Config
           </li>
-          <!-- Collapsible Group for GPT Models -->
           <li @click="isGPTConfigOpen = !isGPTConfigOpen">
+            <ChevronDown v-if="isGPTConfigOpen || selectedModel.includes('gpt')" :size="12" />
+            <ChevronRight v-else :size="12" />
             GPT Models
-            <span class="indicator">{{ isGPTConfigOpen || selectedModel.includes('gpt') ? '-' : '+' }}</span>
           </li>
-          <ul v-show="isGPTConfigOpen || selectedModel.includes('gpt')" class="sub-item">
-            <li v-for="model in models.filter(m => m.value.includes('gpt'))" :key="model.value"
-              :class="{ selected: model.value === selectedModel }" @click="selectModel(model.value)">
-              {{ model.label }}
-            </li>
-          </ul>
+          <transition name="slide-fade">
+            <ul v-show="isGPTConfigOpen || selectedModel.includes('gpt')" class="sub-item">
+              <li v-for="model in models.filter(m => m.value.includes('gpt'))" :key="model.value"
+                :class="{ selected: model.value === selectedModel }" @click="selectModel(model.value)">
+                {{ model.label }}
+              </li>
+            </ul>
+          </transition>
           <li @click="isCustomConfigOpen = !isCustomConfigOpen">
+            <ChevronDown v-if="isCustomConfigOpen || selectedModel === 'open-ai-format'" :size="12" />
+            <ChevronRight v-else :size="12" />
             Custom Models
-            <span class="indicator">{{ isCustomConfigOpen || selectedModel === 'open-ai-format' ? '-' : '+' }}</span>
           </li>
-          <ul v-show="isCustomConfigOpen || selectedModel === 'open-ai-format'" class="sub-item">
-            <li v-for="(config, index) in customConfigs" :key="config.endpoint"
-              :class="{ selected: selectedModel === 'open-ai-format' && selectedCustomConfigIndex === index }"
-              @click="handleSelectCustomConfig(index)">
-              <Trash2 :size="18" :stroke-width="1.5" @click.stop="handleDeleteCustomConfig(index)" />&nbsp;&nbsp;
-              {{ config.endpoint }}
-            </li>
-            <li v-if="!customConfigs.length" :class="{ selected: selectedModel === 'open-ai-format' }"
-              @click="selectModel('open-ai-format')">
-              Add New Custom API
-            </li>
-          </ul>
+          <transition name="slide-fade">
+            <ul v-show="isCustomConfigOpen || selectedModel === 'open-ai-format'" class="sub-item">
+              <li v-for="(config, index) in customConfigs" :key="config.endpoint"
+                :class="{ selected: selectedModel === 'open-ai-format' && selectedCustomConfigIndex === index }"
+                @click="selectCustomModel(index)">
+                <Trash2 :size="18" :stroke-width="1.5" @click.stop="handleDeleteCustomConfig(index)" />&nbsp;&nbsp;
+                {{ config.endpoint }}
+              </li>
+              <li v-if="!customConfigs.length" :class="{ selected: selectedModel === 'open-ai-format' }"
+                @click="selectModel('open-ai-format')">
+                Add New Custom API
+              </li>
+            </ul>
+          </transition>
           <li :class="{ selected: selectedModel === 'web-llm' && !selectedCustomConfig }"
             @click="selectModel('web-llm')">
             Browser Model
@@ -310,6 +321,24 @@ $border-color: #1b6a72c4;
 $header-border-color: #424045b5;
 $bottom-panel-bg-color: #1d1e1e;
 $bottom-panel-border-color: #5f4575cf;
+
+.slide-fade-enter-active,
+.slide-fade-leave-active {
+  transition: all 0.15s ease-out;
+  max-height: 30vh;
+}
+
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+  max-height: 0;
+  opacity: 0;
+  transform: translateY(-20px);
+}
+
+.scale-enter-active,
+.scale-leave-active {
+  transition: transform 0.15s ease-out;
+}
 
 .p-sidebar {
   background-color: #292929;

--- a/src/components/dialogs/SettingsDialog.vue
+++ b/src/components/dialogs/SettingsDialog.vue
@@ -745,7 +745,7 @@ $bottom-panel-border-color: #5f4575cf;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 60vh;
+  height: 70vh;
   transition: width 0.15s ease;
   animation: slideIn 0.15s ease-out backwards;
 
@@ -852,7 +852,7 @@ $bottom-panel-border-color: #5f4575cf;
   overflow-y: auto;
   scrollbar-width: none;
   background-color: #1d1e1e;
-  max-height: 59vh;
+  max-height: 70vh;
   overflow-x: hidden;
 
   @media (max-width: 600px) {

--- a/src/components/dialogs/StoredFilesDialog.vue
+++ b/src/components/dialogs/StoredFilesDialog.vue
@@ -183,8 +183,11 @@ const uploadFile = async (event) => {
 
         reader.onload = async (e) => {
             const contents = e.target.result;
-
-            if (file.type === 'application/pdf') {
+            if (file.type.startsWith('image/')) {
+                // For image files, store the data URL
+                await storeFileData(file.name, contents, file.size, file.type);
+            }
+            else if (file.type === 'application/pdf') {
                 try {
                     const loadingTask = pdfjsLib.getDocument({ data: contents });
                     const pdfDoc = await loadingTask.promise;
@@ -213,7 +216,9 @@ const uploadFile = async (event) => {
             files.value = await fetchStoredFiles();
         };
 
-        if (file.type === 'application/pdf') {
+        if (file.type.startsWith('image/')) {
+            reader.readAsDataURL(file);
+        } else if (file.type === 'application/pdf') {
             reader.readAsArrayBuffer(file);
         } else {
             reader.readAsText(file);

--- a/src/libs/state-management/state.js
+++ b/src/libs/state-management/state.js
@@ -14,6 +14,9 @@ export const audioIsPlaying = ref(false);
 export const availableModels = ref([]);
 export const showStoredFiles = ref(false);
 
+export const isAvatarEnabled = ref((localStorage.getItem("isAvatarEnabled") || false));
+export const avatarUrl = ref((localStorage.getItem("avatarUrl") || ""));
+
 export const contextMenuOpened = ref(false);
 export const shouldShowScrollButton = ref(false);
 export const userText = ref('');

--- a/src/libs/state-management/watchers.js
+++ b/src/libs/state-management/watchers.js
@@ -29,7 +29,9 @@ import {
   ttsModel,
   audioSpeed,
   whisperTemperature,
-  ttsVoice
+  ttsVoice,
+  isAvatarEnabled,
+  avatarUrl
 } from '@/libs/state-management/state';
 
 export function setupWatchers() {
@@ -81,6 +83,8 @@ export function setupWatchers() {
     { ref: ttsVoice, key: 'tts-voice' },
     { ref: audioSpeed, key: 'audio-speed' },
     { ref: whisperTemperature, key: 'whisper-temperature' },
+    { ref: avatarUrl, key: 'avatarUrl' },
+    { ref: isAvatarEnabled, key: 'isAvatarEnabled' },
   ];
 
   refsToWatch.forEach(({ ref, key }) => watchAndStore(ref, key));

--- a/src/libs/utils/settings-utils.js
+++ b/src/libs/utils/settings-utils.js
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import { selectedModel, ttsVoice, whisperTemperature, audioSpeed, ttsModel, useWhisper, pushToTalkMode, higherContrastMessages, isSidebarOpen, systemPrompt, localModelName, localSliderValue, top_P, repetitionPenalty, maxTokens, localModelEndpoint, localModelKey, selectedAutoSaveOption, browserModelSelection, gptKey, sliderValue, claudeKey, claudeSliderValue, selectedDallEImageCount, selectedDallEImageResolution, availableModels } from '../state-management/state';
+import { isAvatarEnabled, avatarUrl, selectedModel, ttsVoice, whisperTemperature, audioSpeed, ttsModel, useWhisper, pushToTalkMode, higherContrastMessages, isSidebarOpen, systemPrompt, localModelName, localSliderValue, top_P, repetitionPenalty, maxTokens, localModelEndpoint, localModelKey, selectedAutoSaveOption, browserModelSelection, gptKey, sliderValue, claudeKey, claudeSliderValue, selectedDallEImageCount, selectedDallEImageResolution, availableModels } from '../state-management/state';
 import { removeAPIEndpoints, showToast } from "./general-utils";
 import { getOpenAICompatibleAvailableModels } from '../api-access/open-ai-api-standard-access';
 
@@ -59,6 +59,8 @@ export function update(field, value) {
   if (field === 'tts-model') ttsModel.value = value;
   if (field === 'tts-voice') ttsVoice.value = value;
   if (field === 'whisper-temperature') whisperTemperature.value = value;
+  if (field === 'isAvatarEnabled') isAvatarEnabled.value = value;
+  if (field === 'avatarUrl') avatarUrl.value = value;
 }
 
 

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ import Ripple from 'primevue/ripple';
 import Menu from 'primevue/menu';
 import ContextMenu from 'primevue/contextmenu';
 import Knob from 'primevue/knob';
+import VirtualScroller from 'primevue/virtualscroller';
 
 import 'primeicons/primeicons.css';
 import 'primevue/resources/themes/aura-dark-green/theme.css';
@@ -41,5 +42,6 @@ app.component('Listbox', Listbox);
 app.component('Menu', Menu);
 app.component('ContextMenu', ContextMenu);
 app.component('Knob', Knob);
+app.component('VirtualScroller', VirtualScroller);
 
 app.mount('#app');

--- a/src/main.js
+++ b/src/main.js
@@ -17,8 +17,7 @@ import Listbox from 'primevue/listbox';
 import Ripple from 'primevue/ripple';
 import Menu from 'primevue/menu';
 import ContextMenu from 'primevue/contextmenu';
-import Knob from 'primevue/knob';
-import VirtualScroller from 'primevue/virtualscroller';
+import Avatar from 'primevue/avatar';
 
 import 'primeicons/primeicons.css';
 import 'primevue/resources/themes/aura-dark-green/theme.css';
@@ -41,7 +40,7 @@ app.component('InputText', InputText);
 app.component('Listbox', Listbox);
 app.component('Menu', Menu);
 app.component('ContextMenu', ContextMenu);
-app.component('Knob', Knob);
-app.component('VirtualScroller', VirtualScroller);
+app.component('Avatar', Avatar);
+
 
 app.mount('#app');

--- a/src/views/ChatLayout.vue
+++ b/src/views/ChatLayout.vue
@@ -383,15 +383,14 @@ pre {
   min-width: 25vw;
   max-width: 100vw;
   position: fixed;
-  top: 15%;
+  top: 5%;
   padding: 0;
   border-right: 2px solid $border-color;
   z-index: 1;
   border-radius: 12px;
   border: 2px solid #083e35d9;
   width: 60vw;
-  height: 70vh;
-  top: 15%;
+  height: 85vh;
   font-size: 12px;
 
   @media (max-width: 600px) {


### PR DESCRIPTION
### Summary
---

- Added the ability for users to enable/disable an AI message avatar picture.
- Added the ability for users to choose from existing stored images or upload directly an image to use for the AI avatar image. 
- Added and aligned animations for opening and closing config sections etc..
- Increase height of the configuration page in the desktop layout

### Images
---
![Screenshot_22-6-2024_183227_localhost](https://github.com/fingerthief/minimal-chat/assets/2380471/8b915589-9824-478f-9a5d-595fade68620)

![Screenshot_22-6-2024_183712_localhost](https://github.com/fingerthief/minimal-chat/assets/2380471/5cbe439d-6d34-4e6a-8602-283245ad98da)

### Auto Generated Notes (Do Not Change)

---

<!--- START AUTOGENERATED NOTES --->
# Contents ([#168](https://github.com/fingerthief/minimal-chat/pull/168))

### Uncategorised!
- Fixed issue with selecting custom configs in certain scenarios
- Added ability to set an AI avatar image. This can be done either via a URL to a link or by uploading and choosing an image from your stored files.

<!--- END AUTOGENERATED NOTES --->